### PR TITLE
Fix #33: Implement states in signin

### DIFF
--- a/common-datasource/src/main/java/ke/don/common_datasource/local/datastore/profile/ProfileDataStoreManager.kt
+++ b/common-datasource/src/main/java/ke/don/common_datasource/local/datastore/profile/ProfileDataStoreManager.kt
@@ -2,7 +2,9 @@ package ke.don.common_datasource.local.datastore.profile
 
 import android.content.Context
 import ke.don.shared_domain.data_models.Profile
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.last
 
 class ProfileDataStoreManager(private val context : Context) {
     suspend fun setProfileInDatastore(profile : Profile){
@@ -19,6 +21,8 @@ class ProfileDataStoreManager(private val context : Context) {
     }
 
     suspend fun getProfileFromDatastore(): Profile{
-        return context.profileDataStore.data.first()
+        return context.profileDataStore.data
+            .filter { it.authId.isNotEmpty() } // Wait until the profile has a valid ID
+            .first()
     }
 }

--- a/common-datasource/src/main/java/ke/don/common_datasource/remote/data/di/DatasourceModule.kt
+++ b/common-datasource/src/main/java/ke/don/common_datasource/remote/data/di/DatasourceModule.kt
@@ -57,12 +57,10 @@ object DatasourceModule {
         profileNetworkClass: ProfileNetworkClass,
         profileDataStoreManager: ProfileDataStoreManager,
         @ApplicationContext context: Context,
-        userProfile: Profile?
     ): ProfileRepository = ProfileRepositoryImpl(
         profileNetworkClass = profileNetworkClass,
         profileDataStoreManager = profileDataStoreManager,
         context = context,
-        profile = userProfile
     )
 
     @Provides

--- a/common-datasource/src/main/java/ke/don/common_datasource/remote/data/profile/repositoryImpl/ProfileRepositoryImpl.kt
+++ b/common-datasource/src/main/java/ke/don/common_datasource/remote/data/profile/repositoryImpl/ProfileRepositoryImpl.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.launch
 class ProfileRepositoryImpl(
     private val profileNetworkClass: ProfileNetworkClass,
     private val context: Context,
-    private val profile: Profile?,
     private val profileDataStoreManager: ProfileDataStoreManager
 ): ProfileRepository {
     override val rawNonce: String

--- a/feature-authentication/src/main/java/ke/don/feature_authentication/data/GoogleSignInClient.kt
+++ b/feature-authentication/src/main/java/ke/don/feature_authentication/data/GoogleSignInClient.kt
@@ -5,25 +5,18 @@ import android.util.Log
 import android.widget.Toast
 import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
-import androidx.credentials.exceptions.GetCredentialException
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
-import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
 import ke.don.common_datasource.remote.domain.repositories.ProfileRepository
 import ke.don.shared_domain.BuildConfig
+import ke.don.shared_domain.states.ResultState
 import ke.don.shared_domain.values.MAX_RETRIES
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 
 class GoogleSignInClient(
     private val context: Context,
     private val profileRepository: ProfileRepository
 ) {
-    private val _isSignInSuccessful = MutableStateFlow(false)
-    val isSignInSuccessful: StateFlow<Boolean> = _isSignInSuccessful
-
-
     private val credentialManager = CredentialManager.create(context)
 
 
@@ -41,17 +34,13 @@ class GoogleSignInClient(
 
 
 
-    suspend fun signInWithGoogle() {
-        val maxRetries = MAX_RETRIES
-        var attempt = 0
-
-        while (attempt < maxRetries) {
+    suspend fun signInWithGoogle(): ResultState {
+        for (attempt in 1..MAX_RETRIES) {
             try {
                 val result = credentialManager.getCredential(
                     request = request,
                     context = context
                 )
-
                 val credential = result.credential
                 val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
                 val googleIdToken = googleIdTokenCredential.idToken
@@ -59,28 +48,34 @@ class GoogleSignInClient(
                 val displayName = googleIdTokenCredential.displayName
                 val profilePictureUri = googleIdTokenCredential.profilePictureUri?.toString()
 
-                if (displayName != null && profilePictureUri != null) {
-                    if(profileRepository.signInAndInsertProfile(googleIdToken, displayName, profilePictureUri)){
-                        _isSignInSuccessful.value = true
-                        Toast.makeText(context, "Welcome to Preface", Toast.LENGTH_SHORT).show()
-                        return  // Exit the function after successful sign-in
-                    }
+                if (displayName == null || profilePictureUri == null) {
+                    throw Exception("Missing displayName or profilePictureUri")
                 }
 
+                val signInSuccess = profileRepository.signInAndInsertProfile(
+                    googleIdToken,
+                    displayName,
+                    profilePictureUri
+                )
 
-
-            } catch (e: Exception) {
-                Log.d("GoogleSignInClient", "Attempt ${attempt + 1} failed: ${e.message}")
-                attempt++
-
-                if (attempt < maxRetries) {
-                    delay(2000) // Wait 2 seconds before retrying
+                if (signInSuccess) {
+                    Toast.makeText(context, "Welcome to Preface", Toast.LENGTH_SHORT).show()
+                    return ResultState.Success
                 } else {
+                    throw Exception("Sign in and profile insertion failed")
+                }
+            } catch (e: Exception) {
+                Log.d("GoogleSignInClient", "Attempt $attempt failed: ${e.message}")
+                if (attempt == MAX_RETRIES) {
                     Log.d("GoogleSignInClient", "Max retries reached. Sign in failed.")
                     Toast.makeText(context, "Sign in failed. Please try again later", Toast.LENGTH_SHORT).show()
+                    return ResultState.Error(e.message ?: "Unknown error")
                 }
+                delay(2000) // Wait 2 seconds before retrying
             }
         }
+        // Should never reach here; return a default failure if it does.
+        return ResultState.Error("Unknown error")
     }
 
 }

--- a/feature-authentication/src/main/java/ke/don/feature_authentication/presentation/OnBoardingScreen.kt
+++ b/feature-authentication/src/main/java/ke/don/feature_authentication/presentation/OnBoardingScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -47,6 +48,7 @@ import com.airbnb.lottie.compose.rememberLottieComposition
 import ke.don.feature_authentication.data.animations
 import ke.don.feature_authentication.data.descriptions
 import ke.don.feature_authentication.data.titles
+import ke.don.shared_domain.states.ResultState
 
 
 @Composable
@@ -55,97 +57,107 @@ fun OnboardingScreen(
     viewModel: SignInViewModel = hiltViewModel(),
     onSuccessfulSignIn : () -> Unit
 ) {
-    val isSignInSuccessful by viewModel.isSignInSuccessful.collectAsState()
-
-
-    if (isSignInSuccessful) {
-        onSuccessfulSignIn()
-    }
 
     val pagerState = rememberPagerState(
         pageCount = { animations.size }
     )
 
-    Column(
-        modifier
-            .fillMaxSize()
-            .padding(8.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+    val signInState = viewModel.signInState.collectAsState()
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+    ){
+        Column(
+            modifier
+                .fillMaxSize()
+                .padding(8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
 
-        HorizontalPager(
-            state = pagerState,
-            modifier.wrapContentSize()
-        ) { currentPage ->
-            Column(
-                Modifier
-                    .wrapContentSize()
-                    .padding(26.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
-            ) {
-                val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(animations[currentPage]))
-                LottieAnimation(
-                    composition = composition,
-                    iterations = 1,
-                    modifier = modifier.size(400.dp)
-                )
-                Text(
-                    text = titles[currentPage],
-                    textAlign = TextAlign.Center,
-                    fontSize = 44.sp,
-                    fontWeight = FontWeight.Bold
-                )
-                Text(
-                    text = descriptions[currentPage],
-                    modifier.padding(top = 45.dp),
-                    textAlign = TextAlign.Center,
-                    fontSize = 20.sp
-
-                )
-            }
-        }
-
-        LookaheadScope {
-            Row(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .padding(8.dp),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                PageIndicator(
-                    pageCount = animations.size,
-                    currentPage = pagerState.currentPage,
-                    modifier = modifier.padding(60.dp)
-                )
-
-                AnimatedVisibility(
-                    visible = pagerState.currentPage == 2,
-                    enter = fadeIn(animationSpec = tween(durationMillis = 300)) +
-                            slideInVertically(
-                                initialOffsetY = { it },
-                                animationSpec = spring(stiffness = Spring.StiffnessLow)
-                            ),
-                    exit = fadeOut(animationSpec = tween(durationMillis = 200)) +
-                            slideOutVertically(
-                                targetOffsetY = { it },
-                                animationSpec = spring(stiffness = Spring.StiffnessMedium)
-                            )
+            HorizontalPager(
+                state = pagerState,
+                modifier.wrapContentSize()
+            ) { currentPage ->
+                Column(
+                    Modifier
+                        .wrapContentSize()
+                        .padding(26.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
                 ) {
-                    GoogleSignInButton(
-                        modifier = modifier,
-                        onClickAction = {
-                            viewModel.onSignInWithGoogle()
-                        }
+                    val composition by rememberLottieComposition(
+                        LottieCompositionSpec.RawRes(
+                            animations[currentPage]
+                        )
+                    )
+                    LottieAnimation(
+                        composition = composition,
+                        iterations = 1,
+                        modifier = modifier.size(400.dp)
+                    )
+                    Text(
+                        text = titles[currentPage],
+                        textAlign = TextAlign.Center,
+                        fontSize = 44.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = descriptions[currentPage],
+                        modifier.padding(top = 45.dp),
+                        textAlign = TextAlign.Center,
+                        fontSize = 20.sp
+
                     )
                 }
             }
+
+            LookaheadScope {
+                Row(
+                    modifier = modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    PageIndicator(
+                        pageCount = animations.size,
+                        currentPage = pagerState.currentPage,
+                        modifier = modifier.padding(60.dp)
+                    )
+
+                    AnimatedVisibility(
+                        visible = pagerState.currentPage == 2,
+                        enter = fadeIn(animationSpec = tween(durationMillis = 300)) +
+                                slideInVertically(
+                                    initialOffsetY = { it },
+                                    animationSpec = spring(stiffness = Spring.StiffnessLow)
+                                ),
+                        exit = fadeOut(animationSpec = tween(durationMillis = 200)) +
+                                slideOutVertically(
+                                    targetOffsetY = { it },
+                                    animationSpec = spring(stiffness = Spring.StiffnessMedium)
+                                )
+                    ) {
+                        GoogleSignInButton(
+                            modifier = modifier,
+                            enabled = signInState.value != ResultState.Loading,
+                            onClickAction = {
+                                viewModel.onSignInWithGoogle(onSuccessfulSignIn)
+                            }
+                        )
+                    }
+                }
+            }
+
+
         }
+        if (signInState.value == ResultState.Loading){
+            CircularProgressIndicator()
 
-
-
+        }
     }
+
+
 
 }
 

--- a/feature-authentication/src/main/java/ke/don/feature_authentication/presentation/SignInViewModel.kt
+++ b/feature-authentication/src/main/java/ke/don/feature_authentication/presentation/SignInViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import ke.don.feature_authentication.data.GoogleSignInClient
+import ke.don.shared_domain.states.ResultState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -14,17 +15,24 @@ class SignInViewModel @Inject constructor(
     private val googleSignInClient: GoogleSignInClient
 ): ViewModel() {
 
-    val isSignInSuccessful: StateFlow<Boolean> = googleSignInClient.isSignInSuccessful
+    //val isSignInSuccessful: StateFlow<Boolean> = googleSignInClient.isSignInSuccessful
+    private val _signInState: MutableStateFlow<ResultState> = MutableStateFlow(ResultState.Empty)
+    val signInState: StateFlow<ResultState> = _signInState
 
-
-    fun onSignInWithGoogle(){
+    fun onSignInWithGoogle(onSuccessfulSignIn: () -> Unit){
         try {
+            _signInState.value = ResultState.Loading
             viewModelScope.launch {
-                googleSignInClient.signInWithGoogle()
-
+                if(googleSignInClient.signInWithGoogle() == ResultState.Success){
+                    onSuccessfulSignIn()
+                    _signInState.value = ResultState.Success
+                }else{
+                    _signInState.value = ResultState.Error("Sign in failed")
+                }
             }
         }catch (e: Exception){
             e.printStackTrace()
+            _signInState.value = ResultState.Error(e.message ?: "Unknown error")
         }
 
     }

--- a/feature-authentication/src/main/java/ke/don/feature_authentication/presentation/SignInWithGoogleButton.kt
+++ b/feature-authentication/src/main/java/ke/don/feature_authentication/presentation/SignInWithGoogleButton.kt
@@ -30,14 +30,16 @@ import ke.don.feature_authentication.R
 fun GoogleSignInButton(
     modifier: Modifier = Modifier,
     onClickAction: () -> Unit,
+    enabled: Boolean = true,
     isDarkTheme: Boolean = isSystemInDarkTheme()
 ) {
-    val containerColor = if (isDarkTheme) Color.White else Color.Black
+    val containerColor = MaterialTheme.colorScheme.inverseSurface
     val contentColor = if (isDarkTheme) Color.Black else Color.White
 
     Button(
         onClick = onClickAction,
         shape = RoundedCornerShape(64.dp),
+        enabled = enabled,
         colors = ButtonDefaults.buttonColors(
             containerColor = containerColor,
             contentColor = contentColor


### PR DESCRIPTION
- Remove profile parameter from ProfileRepositoryImpl.
- Update ProfileDataStoreManager to await valid authId.
- Add enabled parameter to GoogleSignInButton.
- Refactor SignInViewModel to use ResultState.
- Update OnBoardingScreen to use signInState.
- Disable GoogleSignInButton during sign-in.
- Update onSignInWithGoogle to include callback.
- Refactor signInWithGoogle to return ResultState.
- Improve signInWithGoogle retry logic.
- Remove isSignInSuccessful stateFlow.
- Adjust signInWithGoogle retries logic.
